### PR TITLE
Docker build tweaks and docker-compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Makefile
+README.md
+Dockerfile
+docker-compose.yml
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,30 @@
-FROM ubuntu
+FROM ubuntu:16.04
 MAINTAINER jose nazario <jose@monkey.org>
 LABEL version="1.0" description="lfi-labs Docker image"
 
-# set up packages
-RUN apt-get -y update  
-RUN apt-get -y install apache2
-RUN apt-get -y install php7.0 libapache2-mod-php7.0
-RUN apt-get -y install git
+ARG DEBIAN_FRONTEND=noninteractive
 
-# install lfi-labs from git
-ENV LFIDIR=/usr/local/lfi-labs
-RUN mkdir $LFIDIR
-WORKDIR $LFIDIR
-RUN git clone https://github.com/paralax/lfi-labs.git
-WORKDIR lfi-labs
-RUN cp -r * /var/www/html
+# set up packages
+RUN apt-get -qq update \
+  && apt-get install -y --no-install-recommends \
+    apache2 \
+    libapache2-mod-php7.0 \
+    php7.0 \
+  && rm -f /var/www/html/index.html \
+  && apt-get -qy autoremove \
+  && apt-get -qy clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && a2enmod php7.0 \
+  && a2enmod rewrite \
+  && echo "ServerRoot /var/www/html" >> /etc/apache2/apache2.conf
+
+ADD . /var/www/html
 WORKDIR /var/www/html
-RUN rm -f /var/www/html/Dockerfile /var/www/html/index.html
 
 # configure apache
-RUN a2enmod php7.0
-RUN a2enmod rewrite
-RUN echo "ServerRoot /var/www/html" >> /etc/apache2/apache2.conf
 
 EXPOSE 80
-CMD /usr/sbin/apache2ctl -D FOREGROUND
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
 
 # docker build -t lfi-labs .
 # docker run -p 8080:80 lfi-labs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: docker-build
+
+docker-build:
+	@docker build -t lfi-labs .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  web:
+    image: lfi-labs
+    hostname: lfiweb
+    build:
+      context: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION
* Dockerfile refactored:
  * Specify ubuntu version - chose current LTS (Xenial - 16.04)
  * Reduce number of layers by using single RUN directive (reduce image size - leverage docker image layer cache)
  * Clean up apt after install/update (reduce image size)
  * Since the build context is the repository, the `git clone` was removed.
* Adds [a .dockerignore file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) which allows us to exclude files from the final build
* Introduces a very basic Makefile - usage: `make docker-build`
* Introduces a basic `docker-compose` setup - usage: `docker-compose up`